### PR TITLE
Add stack exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,9 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `reverse_linked_list.py` - reverter uma lista ligada simples.
 - `detect_cycle.py` - verificar presen\xc3\xa7a de ciclos em uma lista ligada.
 - `merge_sorted_lists.py` - mesclar duas listas ligadas ordenadas.
+
+### Stacks
+
+- `validate_parentheses.py` - verificar se uma sequência de parênteses está balanceada.
+- `min_stack.py` - pilha que retorna o valor mínimo em O(1).
+- `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.

--- a/algorithms/stacks/evaluate_postfix.py
+++ b/algorithms/stacks/evaluate_postfix.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def evaluate_postfix(expression: str) -> int:
+    """Avalia uma express\u00e3o em nota\u00e7\u00e3o p\u00f3s-fixa.
+
+    A express\u00e3o deve conter operandos e operadores separados por espa\u00e7os.
+    Suporta ``+``, ``-``, ``*`` e ``/`` (divis\u00e3o inteira).
+
+    Args:
+        expression: string da express\u00e3o p\u00f3s-fixa.
+
+    Returns:
+        Resultado inteiro da avalia\u00e7\u00e3o.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/stacks/min_stack.py
+++ b/algorithms/stacks/min_stack.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+class MinStack:
+    """Pilha que permite obter o menor elemento em O(1)."""
+
+    def __init__(self) -> None:
+        self._stack: list[int] = []
+        self._mins: list[int] = []
+
+    def push(self, value: int) -> None:
+        """Insere um valor no topo da pilha."""
+        raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")
+
+    def pop(self) -> int:
+        """Remove e retorna o topo da pilha."""
+        raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")
+
+    def top(self) -> int:
+        """Retorna o valor do topo sem remov\u00ea-lo."""
+        raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")
+
+    def get_min(self) -> int:
+        """Retorna o menor valor presente na pilha."""
+        raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/stacks/test_evaluate_postfix.py
+++ b/algorithms/stacks/test_evaluate_postfix.py
@@ -1,0 +1,15 @@
+from .evaluate_postfix import evaluate_postfix
+
+
+def test_simple_addition():
+    assert evaluate_postfix("2 3 +") == 5
+
+
+def test_complex_expression():
+    expr = "5 1 2 + 4 * + 3 -"
+    assert evaluate_postfix(expr) == 14
+
+
+def test_mixed_operations():
+    assert evaluate_postfix("2 1 + 3 *") == 9
+    assert evaluate_postfix("4 13 5 / +") == 6

--- a/algorithms/stacks/test_min_stack.py
+++ b/algorithms/stacks/test_min_stack.py
@@ -1,0 +1,26 @@
+from .min_stack import MinStack
+
+
+def test_basic_operations():
+    s = MinStack()
+    s.push(3)
+    assert s.get_min() == 3
+    s.push(5)
+    assert s.get_min() == 3
+    s.push(2)
+    assert s.get_min() == 2
+    s.push(1)
+    assert s.get_min() == 1
+    assert s.pop() == 1
+    assert s.get_min() == 2
+    assert s.top() == 2
+    assert s.pop() == 2
+    assert s.get_min() == 3
+
+
+def test_single_element():
+    s = MinStack()
+    s.push(10)
+    assert s.top() == 10
+    assert s.get_min() == 10
+    assert s.pop() == 10

--- a/algorithms/stacks/test_validate_parentheses.py
+++ b/algorithms/stacks/test_validate_parentheses.py
@@ -1,0 +1,21 @@
+from .validate_parentheses import is_valid_parentheses
+
+
+def test_empty_string():
+    assert is_valid_parentheses("") is True
+
+
+def test_simple_valid():
+    assert is_valid_parentheses("()") is True
+
+
+def test_complex_valid():
+    assert is_valid_parentheses("([]{})") is True
+
+
+def test_mismatch():
+    assert is_valid_parentheses("(]") is False
+
+
+def test_wrong_order():
+    assert is_valid_parentheses("([)]") is False

--- a/algorithms/stacks/validate_parentheses.py
+++ b/algorithms/stacks/validate_parentheses.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+def is_valid_parentheses(expression: str) -> bool:
+    """Verifica se todos os par\u00eanteses est\u00e3o balanceados.
+
+    Args:
+        expression: sequ\u00eancia contendo par\u00eanteses e outros caracteres.
+
+    Returns:
+        ``True`` se a sequ\u00eancia \u00e9 bem-formada; caso contr\u00e1rio ``False``.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")


### PR DESCRIPTION
## Summary
- add new Stacks section with three practice challenges
- provide implementation stubs for stack algorithms and related tests
- list the Stacks tasks in README

## Testing
- `pytest -q`
- `pytest algorithms/stacks/test_validate_parentheses.py::test_simple_valid -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9a66b4e083318da607a6d35f0299