### PR TITLE
Add binary tree stubs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,9 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `reverse_linked_list.py` - reverter uma lista ligada simples.
 - `detect_cycle.py` - verificar presen\xc3\xa7a de ciclos em uma lista ligada.
 - `merge_sorted_lists.py` - mesclar duas listas ligadas ordenadas.
+
+### \xc3\x81rvores Bin\xc3\xa1rias
+
+- `balance_bst.py` - balancear uma BST desbalanceada.
+- `nivel_ordem.py` - percorrer a \xc3\xa1rvore em ordem de n\xc3\xadvel.
+- `is_valid_bst.py` - verificar se uma \xc3\xa1rvore \xc3\xa9 uma BST v\xc3\xa1lida.

--- a/algorithms/arvores_binarias/balance_bst.py
+++ b/algorithms/arvores_binarias/balance_bst.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import Optional, List
+
+
+class TreeNode:
+    """N\u00f3 de uma \u00e1rvore bin\u00e1ria de busca (BST)."""
+
+    def __init__(self, value: int, left: Optional['TreeNode'] | None = None, right: Optional['TreeNode'] | None = None) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def balance_bst(root: Optional[TreeNode]) -> Optional[TreeNode]:
+    """Balanceia uma BST desbalanceada.
+
+    A fun\u00e7\u00e3o deve receber a raiz de uma BST possivelmente desbalanceada
+    e retornar uma nova \u00e1rvore contendo os mesmos elementos, por\u00e9m com
+    altura m\u00e1xima minimizada.
+
+    Args:
+        root: raiz da BST original.
+
+    Returns:
+        Raiz da nova BST balanceada ou ``None`` se a \u00e1rvore for vazia.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/arvores_binarias/is_valid_bst.py
+++ b/algorithms/arvores_binarias/is_valid_bst.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Optional
+
+
+class TreeNode:
+    """N\u00f3 de uma \u00e1rvore bin\u00e1ria."""
+
+    def __init__(self, value: int, left: Optional['TreeNode'] | None = None, right: Optional['TreeNode'] | None = None) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def is_valid_bst(root: Optional[TreeNode]) -> bool:
+    """Verifica se a \u00e1rvore \u00e9 uma BST v\u00e1lida.
+
+    Args:
+        root: raiz da \u00e1rvore.
+
+    Returns:
+        ``True`` se a \u00e1rvore obedecer as propriedades de uma BST, caso contr\u00e1rio ``False``.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/arvores_binarias/nivel_ordem.py
+++ b/algorithms/arvores_binarias/nivel_ordem.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Optional, List
+
+
+class TreeNode:
+    """N\u00f3 de uma \u00e1rvore bin\u00e1ria."""
+
+    def __init__(self, value: int, left: Optional['TreeNode'] | None = None, right: Optional['TreeNode'] | None = None) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def nivel_ordem(root: Optional[TreeNode]) -> List[int]:
+    """Percorre a \u00e1rvore em ordem de n\u00edvel (BFS).
+
+    Args:
+        root: raiz da \u00e1rvore bin\u00e1ria.
+
+    Returns:
+        Lista com os valores dos n\u00f3s em ordem de n\u00edvel.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/arvores_binarias/test_balance_bst.py
+++ b/algorithms/arvores_binarias/test_balance_bst.py
@@ -1,0 +1,58 @@
+from .balance_bst import TreeNode, balance_bst
+
+
+def insert(root, value):
+    if root is None:
+        return TreeNode(value)
+    if value < root.value:
+        root.left = insert(root.left, value)
+    else:
+        root.right = insert(root.right, value)
+    return root
+
+
+def inorder(node):
+    result = []
+    stack = []
+    current = node
+    while stack or current:
+        while current:
+            stack.append(current)
+            current = current.left
+        current = stack.pop()
+        result.append(current.value)
+        current = current.right
+    return result
+
+
+def height(node):
+    if not node:
+        return 0
+    return 1 + max(height(node.left), height(node.right))
+
+
+def build_skewed(values):
+    root = None
+    for v in values:
+        root = insert(root, v)
+    return root
+
+
+def test_empty_tree():
+    assert balance_bst(None) is None
+
+
+def test_single_node():
+    node = TreeNode(1)
+    result = balance_bst(node)
+    assert result.value == 1
+    assert result.left is None
+    assert result.right is None
+
+
+def test_balance_height_and_order():
+    values = list(range(1, 8))
+    root = build_skewed(values)
+    balanced = balance_bst(root)
+    assert inorder(balanced) == values
+    assert height(balanced) <= 3

--- a/algorithms/arvores_binarias/test_is_valid_bst.py
+++ b/algorithms/arvores_binarias/test_is_valid_bst.py
@@ -1,0 +1,27 @@
+from .is_valid_bst import TreeNode, is_valid_bst
+
+
+def test_empty():
+    assert is_valid_bst(None) is True
+
+
+def test_simple_valid():
+    root = TreeNode(2)
+    root.left = TreeNode(1)
+    root.right = TreeNode(3)
+    assert is_valid_bst(root) is True
+
+
+def test_invalid_subtree():
+    root = TreeNode(5)
+    root.left = TreeNode(1)
+    root.right = TreeNode(4)
+    root.right.left = TreeNode(3)
+    root.right.right = TreeNode(6)
+    assert is_valid_bst(root) is False
+
+
+def test_invalid_left_greater():
+    root = TreeNode(5)
+    root.left = TreeNode(7)
+    assert is_valid_bst(root) is False

--- a/algorithms/arvores_binarias/test_nivel_ordem.py
+++ b/algorithms/arvores_binarias/test_nivel_ordem.py
@@ -1,0 +1,25 @@
+from .nivel_ordem import TreeNode, nivel_ordem
+
+
+def build_tree():
+    root = TreeNode(1)
+    root.left = TreeNode(2)
+    root.right = TreeNode(3)
+    root.left.left = TreeNode(4)
+    root.left.right = TreeNode(5)
+    root.right.right = TreeNode(6)
+    return root
+
+
+def test_empty():
+    assert nivel_ordem(None) == []
+
+
+def test_single_node():
+    root = TreeNode(7)
+    assert nivel_ordem(root) == [7]
+
+
+def test_level_order():
+    root = build_tree()
+    assert nivel_ordem(root) == [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
## Summary
- add folder `arvores_binarias`
- stub out `balance_bst`, `nivel_ordem` and `is_valid_bst`
- add corresponding pytest suites
- document binary tree tasks in README

## Testing
- `pytest -q`
- `pytest algorithms/arvores_binarias/test_balance_bst.py::test_empty_tree -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9a87bed4833194c55b34ab2810e0