### PR TITLE
Add BST search challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `balance_bst.py` - balancear uma BST desbalanceada.
 - `nivel_ordem.py` - percorrer a \xc3\xa1rvore em ordem de n\xc3\xadvel.
 - `is_valid_bst.py` - verificar se uma \xc3\xa1rvore \xc3\xa9 uma BST v\xc3\xa1lida.
+- `search_bst.py` - buscar um valor em uma BST.
 
 ### Queues
 

--- a/algorithms/arvores_binarias/search_bst.py
+++ b/algorithms/arvores_binarias/search_bst.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Optional
+
+
+class TreeNode:
+    """Nó de uma árvore binária de busca (BST)."""
+
+    def __init__(self, value: int, left: Optional['TreeNode'] | None = None, right: Optional['TreeNode'] | None = None) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def search_bst(root: Optional[TreeNode], target: int) -> Optional[TreeNode]:
+    """Busca um valor na BST e retorna o nó correspondente.
+
+    Args:
+        root: raiz da BST.
+        target: valor a ser buscado.
+
+    Returns:
+        O nó contendo ``target`` ou ``None`` se não encontrado.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/arvores_binarias/test_search_bst.py
+++ b/algorithms/arvores_binarias/test_search_bst.py
@@ -1,0 +1,47 @@
+from .search_bst import TreeNode, search_bst
+
+
+def insert(root, value):
+    if root is None:
+        return TreeNode(value)
+    if value < root.value:
+        root.left = insert(root.left, value)
+    else:
+        root.right = insert(root.right, value)
+    return root
+
+
+def build_bst(values):
+    root = None
+    for v in values:
+        root = insert(root, v)
+    return root
+
+
+def test_empty_tree():
+    assert search_bst(None, 1) is None
+
+
+def test_single_node_found():
+    node = TreeNode(2)
+    result = search_bst(node, 2)
+    assert result is node
+
+
+def test_single_node_not_found():
+    node = TreeNode(2)
+    assert search_bst(node, 3) is None
+
+
+def test_search_existing():
+    values = [4, 2, 6, 1, 3, 5, 7]
+    root = build_bst(values)
+    result = search_bst(root, 5)
+    assert result is not None
+    assert result.value == 5
+
+
+def test_search_missing():
+    values = [4, 2, 6, 1, 3, 5, 7]
+    root = build_bst(values)
+    assert search_bst(root, 8) is None


### PR DESCRIPTION
## Summary
- add stub for `search_bst` implementation
- add tests for searching nodes in a BST
- list the new challenge in the README

## Testing
- `pytest algorithms/arvores_binarias/test_search_bst.py -q`
- `pytest -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9d2c66088331900049b20ec1e40c