### PR TITLE
Add BST node deletion challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Para ilustrar concretamente, vejamos um exemplo de como o agente atuaria dado um
      - Testa uma árvore com vários níveis, incluindo nós faltantes, etc.
      - Testa árvore nula (None) retorna lista vazia.
    - `is_valid_bst.py` com função `is_valid_bst(root)` e stub.
+- `delete_bst_node.py` - remover um nó de uma BST.
    - `test_is_valid_bst.py` com testes:
      - Vários cenários de árvore válida e inválida (violações sutis, e.g. um nodo numa subárvore direita que é menor que a raiz ancestral).
      - Casos de um nó, nenhum nó, etc.
@@ -236,6 +237,7 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `balance_bst.py` - balancear uma BST desbalanceada.
 - `nivel_ordem.py` - percorrer a \xc3\xa1rvore em ordem de n\xc3\xadvel.
 - `is_valid_bst.py` - verificar se uma \xc3\xa1rvore \xc3\xa9 uma BST v\xc3\xa1lida.
+- `delete_bst_node.py` - remover um nó de uma BST.
 
 ### Queues
 

--- a/algorithms/arvores_binarias/delete_bst_node.py
+++ b/algorithms/arvores_binarias/delete_bst_node.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Optional
+
+
+class TreeNode:
+    """N\u00f3 de uma \u00e1rvore bin\u00e1ria de busca (BST)."""
+
+    def __init__(self, value: int, left: Optional['TreeNode'] | None = None, right: Optional['TreeNode'] | None = None) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def delete_bst_node(root: Optional[TreeNode], key: int) -> Optional[TreeNode]:
+    """Remove o n\u00f3 com o valor ``key`` de uma BST.
+
+    Args:
+        root: raiz da BST.
+        key: valor a ser removido.
+
+    Returns:
+        A raiz da BST ap\u00f3s a remo\u00e7\u00e3o do n\u00f3.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/arvores_binarias/test_delete_bst_node.py
+++ b/algorithms/arvores_binarias/test_delete_bst_node.py
@@ -1,0 +1,45 @@
+from .delete_bst_node import TreeNode, delete_bst_node
+
+
+def insert(root, value):
+    if root is None:
+        return TreeNode(value)
+    if value < root.value:
+        root.left = insert(root.left, value)
+    else:
+        root.right = insert(root.right, value)
+    return root
+
+
+def inorder(node):
+    if node is None:
+        return []
+    return inorder(node.left) + [node.value] + inorder(node.right)
+
+
+def test_delete_from_empty():
+    assert delete_bst_node(None, 5) is None
+
+
+def test_delete_leaf():
+    root = TreeNode(5)
+    root.left = TreeNode(3)
+    root.right = TreeNode(7)
+    result = delete_bst_node(root, 3)
+    assert inorder(result) == [5, 7]
+
+
+def test_delete_single_child():
+    root = TreeNode(5)
+    root.left = TreeNode(3)
+    root.left.left = TreeNode(2)
+    result = delete_bst_node(root, 3)
+    assert inorder(result) == [2, 5]
+
+
+def test_delete_two_children():
+    root = None
+    for v in [5, 3, 8, 2, 4, 7, 9]:
+        root = insert(root, v)
+    result = delete_bst_node(root, 3)
+    assert inorder(result) == [2, 4, 5, 7, 8, 9]


### PR DESCRIPTION
## Summary
- add `delete_bst_node` stub and tests
- document new challenge in README

## Testing
- `pytest algorithms/arvores_binarias/test_delete_bst_node.py -q`
- `pytest -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9d67f744833195c3fbc7cbcd786b