### PR TITLE
Add graph adjacency list exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,9 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
 
+
+### Grafos
+
+- `grafo_adj_list.py` - grafo usando lista de adjacência.
+- `busca_largura.py` - percurso em largura (BFS) em grafos.
+- `busca_profundidade.py` - percurso em profundidade (DFS) em grafos.

--- a/algorithms/grafos/busca_largura.py
+++ b/algorithms/grafos/busca_largura.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict, List
+
+
+def busca_largura(adj: Dict[int, List[int]], inicio: int) -> List[int]:
+    """Realiza busca em largura (BFS) em um grafo.
+
+    Args:
+        adj: mapeamento de cada vértice para sua lista de vizinhos.
+        inicio: vértice de início da busca.
+
+    Returns:
+        Lista de vértices na ordem em que foram visitados.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/grafos/busca_profundidade.py
+++ b/algorithms/grafos/busca_profundidade.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict, List
+
+
+def busca_profundidade(adj: Dict[int, List[int]], inicio: int) -> List[int]:
+    """Realiza busca em profundidade (DFS) em um grafo.
+
+    Args:
+        adj: mapeamento de vértice para vizinhos.
+        inicio: vértice inicial.
+
+    Returns:
+        Lista de vértices visitados na ordem da DFS.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/grafos/grafo_adj_list.py
+++ b/algorithms/grafos/grafo_adj_list.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import List
+
+
+class Grafo:
+    """Grafo não direcionado usando lista de adjacência."""
+
+    def __init__(self, num_vertices: int) -> None:
+        self.num_vertices = num_vertices
+        self.adj: list[list[int]] = [[] for _ in range(num_vertices)]
+
+    def adiciona_aresta(self, u: int, v: int) -> None:
+        """Adiciona uma aresta entre ``u`` e ``v``."""
+        raise NotImplementedError("Implementar esta função")
+
+    def vizinhos(self, u: int) -> List[int]:
+        """Retorna a lista de vértices adjacentes a ``u``."""
+        raise NotImplementedError("Implementar esta função")

--- a/algorithms/grafos/test_busca_largura.py
+++ b/algorithms/grafos/test_busca_largura.py
@@ -1,0 +1,13 @@
+from .busca_largura import busca_largura
+
+
+def test_bfs_basico():
+    grafo = {0: [1, 2], 1: [0, 3], 2: [0], 3: [1]}
+    ordem = busca_largura(grafo, 0)
+    assert ordem == [0, 1, 2, 3]
+
+
+def test_bfs_vertice_isolado():
+    grafo = {0: [], 1: [2], 2: [1]}
+    assert busca_largura(grafo, 0) == [0]
+    assert busca_largura(grafo, 1) == [1, 2]

--- a/algorithms/grafos/test_busca_profundidade.py
+++ b/algorithms/grafos/test_busca_profundidade.py
@@ -1,0 +1,13 @@
+from .busca_profundidade import busca_profundidade
+
+
+def test_dfs_basico():
+    grafo = {0: [1, 2], 1: [0, 3], 2: [0], 3: [1]}
+    ordem = busca_profundidade(grafo, 0)
+    assert ordem == [0, 1, 3, 2]
+
+
+def test_dfs_vertice_isolado():
+    grafo = {0: [], 1: [2], 2: [1]}
+    assert busca_profundidade(grafo, 0) == [0]
+    assert busca_profundidade(grafo, 1) == [1, 2]

--- a/algorithms/grafos/test_grafo_adj_list.py
+++ b/algorithms/grafos/test_grafo_adj_list.py
@@ -1,0 +1,11 @@
+from .grafo_adj_list import Grafo
+
+
+def test_adiciona_e_vizinhos():
+    g = Grafo(3)
+    g.adiciona_aresta(0, 1)
+    g.adiciona_aresta(1, 2)
+    assert sorted(g.vizinhos(1)) == [0, 2]
+    assert g.vizinhos(0) == [1]
+    g.adiciona_aresta(0, 2)
+    assert sorted(g.vizinhos(0)) == [1, 2]


### PR DESCRIPTION
## Summary
- add a new `grafos` module with adjacency-list based challenges
- create BFS and DFS exercises operating on adjacency lists
- document new graph tasks in README

## Testing
- `pytest algorithms/grafos -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9db5939c8331a820091fed8d344c