### PR TITLE
Add BFS shortest path task

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `queue_two_stacks.py` - fila implementada com duas pilhas.
 - `circular_queue.py` - fila circular de tamanho fixo.
 
+### Graphs
+
+- `bfs_shortest_path.py` - encontrar o caminho mais curto em um grafo nao ponderado usando BFS.
 ### Stacks
 
 - `validate_parentheses.py` - verificar se uma sequência de parênteses está balanceada.

--- a/algorithms/graphs/bfs_shortest_path.py
+++ b/algorithms/graphs/bfs_shortest_path.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from collections import deque
+from typing import Dict, List, Hashable
+
+
+def bfs_shortest_path(graph: Dict[Hashable, List[Hashable]], start: Hashable, goal: Hashable) -> List[Hashable]:
+    """Encontra o caminho mais curto entre ``start`` e ``goal`` em um grafo não ponderado.
+
+    O grafo é representado por um dicionário onde cada chave é um vértice e o
+    valor correspondente é uma lista de vizinhos.
+
+    Args:
+        graph: grafo no formato ``{vertice: [vizinhos]}``.
+        start: vértice de origem.
+        goal: vértice de destino.
+
+    Returns:
+        Lista com os vértices do caminho mais curto, incluindo ``start`` e
+        ``goal``. Se não houver caminho possível, retorna uma lista vazia.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/graphs/test_bfs_shortest_path.py
+++ b/algorithms/graphs/test_bfs_shortest_path.py
@@ -1,0 +1,23 @@
+from .bfs_shortest_path import bfs_shortest_path
+
+
+def test_start_equals_goal():
+    graph = {1: [2], 2: []}
+    assert bfs_shortest_path(graph, 1, 1) == [1]
+
+
+def test_simple_path():
+    graph = {1: [2], 2: [3], 3: []}
+    assert bfs_shortest_path(graph, 1, 3) == [1, 2, 3]
+
+
+def test_multiple_paths():
+    graph = {1: [2, 3], 2: [4], 3: [4], 4: []}
+    result = bfs_shortest_path(graph, 1, 4)
+    assert result in ([1, 2, 4], [1, 3, 4])
+    assert len(result) == 3
+
+
+def test_no_path():
+    graph = {1: [2], 2: [], 3: []}
+    assert bfs_shortest_path(graph, 1, 3) == []


### PR DESCRIPTION
## Summary
- add stub `bfs_shortest_path` for computing shortest paths on unweighted graphs
- include tests for this new task
- document new `Graphs` section in README

## Testing
- `pytest -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e11ae2883319eb815b97ec44a5f