### PR TITLE
Add topological sort task

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,7 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
 
+### Graphs
+
+- `topological_sort_dfs.py` - ordenação topológica usando busca em profundidade.
+

--- a/algorithms/graphs/test_topological_sort_dfs.py
+++ b/algorithms/graphs/test_topological_sort_dfs.py
@@ -1,0 +1,20 @@
+from .topological_sort_dfs import topological_sort
+
+
+def test_empty_graph():
+    assert topological_sort({}) == []
+
+
+def test_single_vertex():
+    graph = {"A": []}
+    assert topological_sort(graph) == ["A"]
+
+
+def test_linear_graph():
+    graph = {"A": ["B"], "B": ["C"], "C": ["D"], "D": []}
+    assert topological_sort(graph) == ["A", "B", "C", "D"]
+
+
+def test_unique_order_graph():
+    graph = {"B": ["A", "C"], "A": ["C"], "C": ["D"], "D": []}
+    assert topological_sort(graph) == ["B", "A", "C", "D"]

--- a/algorithms/graphs/topological_sort_dfs.py
+++ b/algorithms/graphs/topological_sort_dfs.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Dict, List
+
+
+def topological_sort(graph: Dict[str, List[str]]) -> List[str]:
+    """Realiza ordena\u00e7\u00e3o topol\u00f3gica em um grafo ac\u00edclico.
+
+    O grafo \u00e9 representado por um dicion\u00e1rio onde cada chave \u00e9 um
+    v\u00e9rtice e o valor \u00e9 a lista de v\u00e9rtices adjacentes.
+
+    Args:
+        graph: dicion\u00e1rio de adjac\u00eancia do grafo direcionado.
+
+    Returns:
+        Lista de v\u00e9rtices em ordem topol\u00f3gica.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")


### PR DESCRIPTION
## Summary
- add graph algorithm folder with topological sort via DFS
- document the new task in `README.md`

## Testing
- `pytest algorithms/graphs/test_topological_sort_dfs.py -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e284a9083318e34e36ba6caac5f