### PR TITLE
Add Huffman decoding challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,7 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
 
+### Huffman
+
+- `huffman_decoding.py` - decodificar mensagem a partir de códigos de Huffman.
+

--- a/algorithms/huffman/huffman_decoding.py
+++ b/algorithms/huffman/huffman_decoding.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict
+
+
+def huffman_decoding(encoded: str, code_map: Dict[str, str]) -> str:
+    """Decodifica uma string codificada utilizando codificação de Huffman.
+
+    Args:
+        encoded: Sequência de bits representando a mensagem codificada.
+        code_map: Mapeamento de caracteres para seus códigos binários.
+
+    Returns:
+        A mensagem original decodificada.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/huffman/test_huffman_decoding.py
+++ b/algorithms/huffman/test_huffman_decoding.py
@@ -1,0 +1,17 @@
+from .huffman_decoding import huffman_decoding
+
+
+def test_basic_decoding():
+    code_map = {'a': '0', 'b': '10', 'c': '11'}
+    encoded = '011011'
+    assert huffman_decoding(encoded, code_map) == 'acac'
+
+
+def test_complex_decoding():
+    code_map = {'a': '0', 'b': '10', 'c': '110', ' ': '111'}
+    encoded = '0101101110'
+    assert huffman_decoding(encoded, code_map) == 'abc a'
+
+
+def test_empty_string():
+    assert huffman_decoding('', {'a': '0'}) == ''


### PR DESCRIPTION
## Summary
- add new Huffman folder with decoding challenge
- include tests for `huffman_decoding`
- document the new challenge in README

## Testing
- `pytest algorithms/huffman/test_huffman_decoding.py -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e355a588331ba4c7bb3a8bcfbce