### PR TITLE
Add min-max stack challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,5 +247,6 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 
 - `validate_parentheses.py` - verificar se uma sequência de parênteses está balanceada.
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
+- `min_max_stack.py` - pilha que retorna os valores mínimo e máximo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
 

--- a/algorithms/stacks/min_max_stack.py
+++ b/algorithms/stacks/min_max_stack.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+
+class MinMaxStack:
+    """Pilha que retorna o valor mínimo e máximo em O(1)."""
+
+    def __init__(self) -> None:
+        self._stack: list[int] = []
+        self._mins: list[int] = []
+        self._maxs: list[int] = []
+
+    def push(self, value: int) -> None:
+        """Insere um valor no topo da pilha."""
+        raise NotImplementedError("Implementar esta função")
+
+    def pop(self) -> int:
+        """Remove e retorna o topo da pilha."""
+        raise NotImplementedError("Implementar esta função")
+
+    def top(self) -> int:
+        """Retorna o valor do topo sem removê-lo."""
+        raise NotImplementedError("Implementar esta função")
+
+    def get_min(self) -> int:
+        """Retorna o menor valor presente na pilha."""
+        raise NotImplementedError("Implementar esta função")
+
+    def get_max(self) -> int:
+        """Retorna o maior valor presente na pilha."""
+        raise NotImplementedError("Implementar esta função")

--- a/algorithms/stacks/test_min_max_stack.py
+++ b/algorithms/stacks/test_min_max_stack.py
@@ -1,0 +1,31 @@
+from .min_max_stack import MinMaxStack
+
+
+def test_basic_operations():
+    s = MinMaxStack()
+    s.push(3)
+    assert s.get_min() == 3
+    assert s.get_max() == 3
+    s.push(5)
+    assert s.get_min() == 3
+    assert s.get_max() == 5
+    s.push(2)
+    assert s.get_min() == 2
+    assert s.get_max() == 5
+    s.push(7)
+    assert s.get_min() == 2
+    assert s.get_max() == 7
+    assert s.pop() == 7
+    assert s.get_max() == 5
+    assert s.top() == 2
+    assert s.pop() == 2
+    assert s.get_min() == 3
+    assert s.get_max() == 5
+
+
+def test_single_element():
+    s = MinMaxStack()
+    s.push(4)
+    assert s.get_min() == 4
+    assert s.get_max() == 4
+    assert s.pop() == 4


### PR DESCRIPTION
## Summary
- add MinMaxStack skeleton and tests
- document challenge in README

## Testing
- `pytest algorithms/stacks/test_min_max_stack.py -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e707f3c8331ba78e7aec5f4f2f8