### PR TITLE
Add Equal Stacks challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,4 +248,5 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `validate_parentheses.py` - verificar se uma sequência de parênteses está balanceada.
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
+- `equal_stacks.py` - equalizar três pilhas removendo do topo.
 

--- a/algorithms/stacks/equal_stacks.py
+++ b/algorithms/stacks/equal_stacks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+def equal_stacks(h1: list[int], h2: list[int], h3: list[int]) -> int:
+    """Reduz as pilhas removendo elementos do topo at\u00e9 que todas tenham a mesma altura.
+
+    Cada lista representa os elementos da pilha do topo para a base. Os valores
+    s\u00e3o as alturas dos cilindros empilhados. A fun\u00e7\u00e3o deve retornar a
+    maior altura poss\u00edvel ap\u00f3s as remo\u00e7\u00f5es. Se n\u00e3o for poss\u00edvel
+    igualar as alturas, retorna ``0``.
+
+    Args:
+        h1: primeira pilha (topo para a base).
+        h2: segunda pilha.
+        h3: terceira pilha.
+
+    Returns:
+        Altura comum m\u00e1xima ap\u00f3s equalizar ou ``0`` se invi\u00e1vel.
+    """
+    raise NotImplementedError("Implementar esta fun\u00e7\u00e3o")

--- a/algorithms/stacks/test_equal_stacks.py
+++ b/algorithms/stacks/test_equal_stacks.py
@@ -1,0 +1,23 @@
+from .equal_stacks import equal_stacks
+
+
+def test_example_case():
+    h1 = [3, 2, 1, 1, 1]
+    h2 = [4, 3, 2]
+    h3 = [1, 1, 4, 1]
+    assert equal_stacks(h1, h2, h3) == 5
+
+
+def test_already_equal():
+    h1 = [2, 2]
+    h2 = [4]
+    h3 = [1, 3]
+    assert equal_stacks(h1, h2, h3) == 4
+
+
+def test_no_possible_height():
+    assert equal_stacks([3], [2], [1]) == 0
+
+
+def test_empty_stacks():
+    assert equal_stacks([], [], []) == 0


### PR DESCRIPTION
## Summary
- add stub for `equal_stacks` algorithm
- add associated tests
- document new task in README

## Testing
- `pytest -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e8503bc8331800834f3207a7e1e