### PR TITLE
Add priority queue challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,9 @@ Em conclusão, as instruções acima servem para configurar o agente de forma cl
 - `min_stack.py` - pilha que retorna o valor mínimo em O(1).
 - `evaluate_postfix.py` - avaliar expressões em notação pós-fixa.
 
+### Priority Queues
+
+- `min_priority_queue.py` - fila de prioridade mínima usando heap.
+- `merge_k_sorted_lists.py` - mesclar múltiplas listas ordenadas.
+- `kth_smallest.py` - encontrar o k-ésimo menor elemento.
+

--- a/algorithms/priority_queues/kth_smallest.py
+++ b/algorithms/priority_queues/kth_smallest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def kth_smallest(nums: List[int], k: int) -> int:
+    """Retorna o ``k``-ésimo menor elemento da lista ``nums``.
+
+    Args:
+        nums: lista de inteiros.
+        k: posição (1-indexada) do menor elemento desejado.
+
+    Returns:
+        Valor do ``k``-ésimo menor elemento.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/priority_queues/merge_k_sorted_lists.py
+++ b/algorithms/priority_queues/merge_k_sorted_lists.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def merge_k_sorted_lists(lists: List[List[int]]) -> List[int]:
+    """Mescla ``k`` listas ordenadas em uma única lista ordenada.
+
+    Args:
+        lists: lista contendo listas já ordenadas.
+
+    Returns:
+        Nova lista com todos os elementos em ordem crescente.
+    """
+    raise NotImplementedError("Implementar esta função")

--- a/algorithms/priority_queues/min_priority_queue.py
+++ b/algorithms/priority_queues/min_priority_queue.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+class MinPriorityQueue:
+    """Fila de prioridade mínima implementada com heap binário."""
+
+    def __init__(self) -> None:
+        self._data: list[int] = []
+
+    def insert(self, item: int) -> None:
+        """Insere ``item`` na fila."""
+        raise NotImplementedError("Implementar esta função")
+
+    def extract_min(self) -> int:
+        """Remove e retorna o menor elemento."""
+        raise NotImplementedError("Implementar esta função")
+
+    def peek_min(self) -> int:
+        """Retorna o menor elemento sem removê-lo."""
+        raise NotImplementedError("Implementar esta função")
+
+    def is_empty(self) -> bool:
+        """Retorna ``True`` se a fila estiver vazia."""
+        raise NotImplementedError("Implementar esta função")
+
+    def size(self) -> int:
+        """Retorna o número de elementos na fila."""
+        raise NotImplementedError("Implementar esta função")

--- a/algorithms/priority_queues/test_kth_smallest.py
+++ b/algorithms/priority_queues/test_kth_smallest.py
@@ -1,0 +1,16 @@
+from .kth_smallest import kth_smallest
+
+
+def test_basic_cases():
+    nums = [7, 10, 4, 3, 20, 15]
+    assert kth_smallest(nums, 3) == 7
+    assert kth_smallest(nums, 1) == 3
+
+
+def test_single_element():
+    assert kth_smallest([5], 1) == 5
+
+
+def test_with_duplicates():
+    nums = [3, 1, 2, 2, 4]
+    assert kth_smallest(nums, 3) == 2

--- a/algorithms/priority_queues/test_merge_k_sorted_lists.py
+++ b/algorithms/priority_queues/test_merge_k_sorted_lists.py
@@ -1,0 +1,15 @@
+from .merge_k_sorted_lists import merge_k_sorted_lists
+
+
+def test_merge_basic():
+    lists = [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+    assert merge_k_sorted_lists(lists) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_merge_with_empty():
+    lists = [[1, 3], [], [2]]
+    assert merge_k_sorted_lists(lists) == [1, 2, 3]
+
+
+def test_all_empty():
+    assert merge_k_sorted_lists([[], [], []]) == []

--- a/algorithms/priority_queues/test_min_priority_queue.py
+++ b/algorithms/priority_queues/test_min_priority_queue.py
@@ -1,0 +1,34 @@
+from .min_priority_queue import MinPriorityQueue
+
+
+def test_insert_and_extract():
+    pq = MinPriorityQueue()
+    pq.insert(5)
+    pq.insert(3)
+    pq.insert(4)
+    assert pq.size() == 3
+    assert pq.peek_min() == 3
+    assert pq.extract_min() == 3
+    assert pq.extract_min() == 4
+    assert pq.extract_min() == 5
+    assert pq.is_empty() is True
+
+
+def test_extract_empty_raises():
+    pq = MinPriorityQueue()
+    try:
+        pq.extract_min()
+    except IndexError:
+        assert True
+    else:
+        assert False, "Deveria lançar IndexError"
+
+
+def test_peek_empty_raises():
+    pq = MinPriorityQueue()
+    try:
+        pq.peek_min()
+    except IndexError:
+        assert True
+    else:
+        assert False, "Deveria lançar IndexError"


### PR DESCRIPTION
## Summary
- create new folder for priority queue problems
- add `MinPriorityQueue` class stub and tests
- add `merge_k_sorted_lists` function stub and tests
- add `kth_smallest` function stub and tests
- document new tasks in README

## Testing
- `pytest -q` *(fails: NotImplementedError)*

------
https://chatgpt.com/codex/tasks/task_e_686e9ec5a4b48331814aef16cb6ba705